### PR TITLE
ci: improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ github.token }}
           branch: main
           maxTagsToFetch: 50
-          patchList: fix,bugfix,perf,refactor,test,tests,bump,chore,doc,docs,ci
+          patchList: fix,bugfix,perf,refactor,test,tests
       - name: Set Version
         if: ${{ success() && steps.semver.outputs.nextStrict != '' }}
         run: npm pkg set version=${{ steps.semver.outputs.nextStrict }}


### PR DESCRIPTION
This commit is to improve release workflow, because bump commit
should not publish per commit.
